### PR TITLE
Patch to fix sourcemaps breaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default function es3 (removeArr) {
           code = code.replace(removeHash[k][0], removeHash[k][1])
         }
       }
-      return code
+      return { code, map: { mappings: '' } }
     }
   }
 }


### PR DESCRIPTION
I'm not sure if this ruins the map itself, but it prevents Rollup from throwing an exception when combining maps at the end of the build.
